### PR TITLE
Feature/support GitHub actions

### DIFF
--- a/XliffSync/Public/Sync-XliffTranslations.ps1
+++ b/XliffSync/Public/Sync-XliffTranslations.ps1
@@ -282,7 +282,7 @@ function Sync-XliffTranslations {
     }
 
     if ($detectSourceTextChanges) {
-        Write-CIMessage -Type ($(if ($detectedSourceTextChanges -lt 1) { "info" } else { "warning" })) -Message "Detected $($detectedSourceTextChanges.Count) source text change(s).";
+        Write-CIMessage -Type ($(if ($detectedSourceTextChanges.Count -lt 1) { "info" } else { "warning" })) -Message "Detected $($detectedSourceTextChanges.Count) source text change(s).";
 
         if ($printProblems -and $detectedSourceTextChanges) {
             $detectedSourceTextChanges | ForEach-Object {

--- a/XliffSync/Public/Sync-XliffTranslations.ps1
+++ b/XliffSync/Public/Sync-XliffTranslations.ps1
@@ -282,7 +282,7 @@ function Sync-XliffTranslations {
     }
 
     if ($detectSourceTextChanges) {
-        Write-CIMessage -Type warning -Message "Detected $($detectedSourceTextChanges.Count) source text change(s).";
+        Write-CIMessage -Type ($(if ($detectedSourceTextChanges -lt 1) { "info" } else { "warning" })) -Message "Detected $($detectedSourceTextChanges.Count) source text change(s).";
 
         if ($printProblems -and $detectedSourceTextChanges) {
             $detectedSourceTextChanges | ForEach-Object {

--- a/XliffSync/Public/Sync-XliffTranslations.ps1
+++ b/XliffSync/Public/Sync-XliffTranslations.ps1
@@ -43,8 +43,8 @@
   Specifies the target tag content for units where the translation is missing.
  .Parameter unitMaps
   Specifies for which search purposes this command should create in-memory maps in preparation of syncing.
- .Parameter AzureDevOps
-  Specifies whether to generate Azure DevOps Pipeline compatible output. This setting determines the severity of errors.
+ .Parameter ErrorSeverity
+  Specifies whether to generate Azure DevOps Pipeline or GitHub Acitons compatible output. This setting determines the severity of errors.
  .Parameter reportProgress
   Specifies whether the command should report progress.
  .Parameter printProblems
@@ -88,8 +88,8 @@ function Sync-XliffTranslations {
         [ValidateSet("None", "Id", "All")]
         [string] $unitMaps = "All",
         [Parameter(Mandatory = $false)]
-        [ValidateSet('no', 'error', 'warning')]
-        [string] $AzureDevOps = 'no',
+        [ValidateSet('info', 'error', 'warning')]
+        [string] $ErrorSeverity = 'info',
         [switch] $reportProgress,
         [switch] $printProblems,
         [switch] $useSelfClosingTags,
@@ -160,12 +160,9 @@ function Sync-XliffTranslations {
     Write-Host "Processing unit nodes... (Please be patient)";
     [string] $progressMessage = "Syncing translation units.";
     if ($reportProgress) {
-        if ($AzureDevOps -ne 'no') {
-            Write-Host "##vso[task.setprogress value=0;]$progressMessage";
-        } else {
-            Write-Progress -Activity $progressMessage -PercentComplete 0;
-        }
+        Write-CIProgress -Message $progressMessage -PercentComplete 0 -ErrorSeverity $ErrorSeverity
     }
+    
 
     $mergedDocument.TranslationUnitNodes() | ForEach-Object {
         [System.Xml.XmlNode] $unit = $_;
@@ -174,11 +171,7 @@ function Sync-XliffTranslations {
             $i++;
             if ($i % $onePercentCount -eq 0) {
                 $percentage = ($i / $unitCount) * 100;
-                if ($AzureDevOps -ne 'no') {
-                    Write-Host "##vso[task.setprogress value=$percentage;]$progressMessage";
-                } else {
-                    Write-Progress -Activity $progressMessage -PercentComplete $percentage;
-                }
+                Write-CIProgress -Message $progressMessage -PercentComplete $percentage -ErrorSeverity $ErrorSeverity
             }
         }
 
@@ -289,16 +282,12 @@ function Sync-XliffTranslations {
     }
 
     if ($detectSourceTextChanges) {
-        Write-Host -ForegroundColor Yellow "Detected $($detectedSourceTextChanges.Count) source text change(s).";
+        Write-CIMessage -Type warning -Message "Detected $($detectedSourceTextChanges.Count) source text change(s).";
 
         if ($printProblems -and $detectedSourceTextChanges) {
-            [string] $detectedMessage = "Detected source text change in unit '{0}'.";
-            if ($AzureDevOps -ne 'no') {
-                $detectedMessage = "##vso[task.logissue type=$AzureDevOps]$detectedMessage";
-            }
-
             $detectedSourceTextChanges | ForEach-Object {
-                Write-Host ($detectedMessage -f (Invoke-Command -ScriptBlock $FormatTranslationUnit -ArgumentList $_));
+                $unitMessage = "Detected source text change in unit '{0}'." -f (Invoke-Command -ScriptBlock $FormatTranslationUnit -ArgumentList $_)
+                Write-CIMessage -Type $ErrorSeverity -Message $unitMessage
             }
         }
     }

--- a/XliffSync/Public/Test-XliffTranslations.ps1
+++ b/XliffSync/Public/Test-XliffTranslations.ps1
@@ -17,8 +17,8 @@
   Specifies which technical validation rules should be used.
  .Parameter translationRulesEnableAll
   Specifies whether to apply all technical validation rules.
- .Parameter AzureDevOps
-  Specifies whether to generate Azure DevOps Pipeline compatible output. This setting determines the severity of errors.
+ .Parameter ErrorSeverity
+  Specifies whether to generate Azure DevOps Pipeline or GitHub Acitons compatible output. This setting determines the severity of errors.
  .Parameter reportProgress
   Specifies whether the command should report progress.
  .Parameter printProblems
@@ -47,8 +47,8 @@ function Test-XliffTranslations {
         [Parameter(Mandatory = $false)]
         [switch] $translationRulesEnableAll,
         [Parameter(Mandatory = $false)]
-        [ValidateSet('no', 'error', 'warning')]
-        [string] $AzureDevOps = 'no',
+        [ValidateSet('info', 'error', 'warning')]
+        [string] $ErrorSeverity = 'info',
         [switch] $reportProgress,
         [switch] $printProblems,
         [ValidateNotNull()]
@@ -86,11 +86,7 @@ function Test-XliffTranslations {
     Write-Host "Processing unit nodes... (Please be patient)";
     [string] $progressMessage = "Checking translation units."
     if ($reportProgress) {
-        if ($AzureDevOps -ne 'no') {
-            Write-Host "##vso[task.setprogress value=0;]$progressMessage";
-        } else {
-            Write-Progress -Activity $progressMessage -PercentComplete 0;
-        }
+        Write-CIProgress -Message $progressMessage -PercentComplete 0 -ErrorSeverity $ErrorSeverity
     }
 
     $targetDocument.TranslationUnitNodes() | ForEach-Object {
@@ -100,11 +96,7 @@ function Test-XliffTranslations {
             $i++;
             if ($i % $onePercentCount -eq 0) {
                 $percentage = ($i / $unitCount) * 100;
-                if ($AzureDevOps -ne 'no') {
-                    Write-Host "##vso[task.setprogress value=$percentage;]$progressMessage";
-                } else {
-                    Write-Progress -Activity $progressMessage -PercentComplete $percentage;
-                }
+                Write-CIProgress -Message $progressMessage -PercentComplete $percentage -ErrorSeverity $ErrorSeverity
             }
         }
 
@@ -131,34 +123,26 @@ function Test-XliffTranslations {
         }
     }
 
-    [int] $missingCount = $missingTranslationUnits.Count;
+    [int] $missingCount = $missingTranslationUnits.Count
     if ($checkForMissing) {
-        Write-Host -ForegroundColor Yellow "Detected: $missingCount missing translation(s).";
+        Write-CIMessage -Type warning -Message "Detected: $missingCount missing translation(s)."
 
         if ($printProblems -and $missingTranslationUnits) {
-            [string] $detectedMessage = "Missing translation in unit '{0}'.";
-            if ($AzureDevOps -ne 'no') {
-                $detectedMessage = "##vso[task.logissue type=$AzureDevOps]$detectedMessage";
-            }
-
             $missingTranslationUnits | ForEach-Object {
-                Write-Host ($detectedMessage -f (Invoke-Command -ScriptBlock $FormatTranslationUnit -ArgumentList $_));
+                $unitMessage = "Missing translation in unit '{0}'." -f (Invoke-Command -ScriptBlock $FormatTranslationUnit -ArgumentList $_)
+                Write-CIMessage -Type $ErrorSeverity -Message $unitMessage
             }
         }
     }
+    
 
     [int] $needWorkCount = $needWorkTranslationUnits.Count;
     if ($checkForProblems) {
-        Write-Host -ForegroundColor Yellow "Detected: $needWorkCount translation(s) that need work.";
+        Write-CIMessage -Type warning -Message "Detected: $needWorkCount translation(s) that need work.";
 
         if ($printProblems -and $needWorkTranslationUnits) {
-            [string] $detectedMessage = "Translation issue in unit '{0}'.";
-            if ($AzureDevOps -ne 'no') {
-                $detectedMessage = "##vso[task.logissue type=$AzureDevOps]$detectedMessage";
-            }
-
             $needWorkTranslationUnits | ForEach-Object {
-                Write-Host ($detectedMessage -f (Invoke-Command -ScriptBlock $FormatTranslationUnit -ArgumentList $_));
+                Write-CIMessage -Type $ErrorSeverity -Message ("Translation issue in unit '{0}'." -f (Invoke-Command -ScriptBlock $FormatTranslationUnit -ArgumentList $_))
             }
         }
     }

--- a/XliffSync/Public/Test-XliffTranslations.ps1
+++ b/XliffSync/Public/Test-XliffTranslations.ps1
@@ -125,7 +125,7 @@ function Test-XliffTranslations {
 
     [int] $missingCount = $missingTranslationUnits.Count
     if ($checkForMissing) {
-        Write-CIMessage -Type warning -Message "Detected: $missingCount missing translation(s)."
+        Write-CIMessage -Type ($(if ($missingCount -lt 1) { "info" } else { "warning" })) -Message "Detected: $missingCount missing translation(s)."
 
         if ($printProblems -and $missingTranslationUnits) {
             $missingTranslationUnits | ForEach-Object {
@@ -138,7 +138,7 @@ function Test-XliffTranslations {
 
     [int] $needWorkCount = $needWorkTranslationUnits.Count;
     if ($checkForProblems) {
-        Write-CIMessage -Type warning -Message "Detected: $needWorkCount translation(s) that need work.";
+        Write-CIMessage -Type ($(if ($needWorkCount -lt 1) { "info" } else { "warning" })) -Message "Detected: $needWorkCount translation(s) that need work.";
 
         if ($printProblems -and $needWorkTranslationUnits) {
             $needWorkTranslationUnits | ForEach-Object {

--- a/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
+++ b/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
@@ -13,8 +13,8 @@
   Specifies whether to apply all technical validation rules.
  .Parameter restrictErrorsToLanguages
   Specifies languages to restrict errors to. For languages not in the list only warnings will be raised. If empty, then the setting of AzureDevOps applies to all languages.
-  .Parameter AzureDevOps
-  Specifies whether to generate Azure DevOps Pipeline compatible output. This setting determines the severity of errors.
+  .Parameter ErrorSeverity
+  Specifies whether to generate Azure DevOps Pipeline or GitHub Acitons compatible output. This setting determines the severity of errors.
  .Parameter reportProgress
   Specifies whether the command should report progress.
  .Parameter printProblems
@@ -33,6 +33,42 @@
  .Parameter testAdditionalParameters
  Specifies additional parameters to pass as arguments to the Test-XliffTranslations function that is invoked by this function.
 #>
+
+function Is-GitHubActions {
+    return [bool]$env:GITHUB_ACTIONS
+}
+
+function Write-CIMessage {
+    param (
+        [Parameter(Mandatory)]
+        [ValidateSet("group", "endgroup", "section", "error", "warning", "info")]
+        [string] $Type,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Message
+    )
+
+    if (Is-GitHubActions) {
+        switch ($Type) {
+            "group" { Write-Host "::group::$Message" }
+            "endgroup" { Write-Host "::endgroup::" }
+            "section" { Write-Host "::group::$Message" }
+            "error" { Write-Host "::error::$Message" }
+            "warning" { Write-Host "::warning::$Message" }
+            default { Write-Host "$Message" }
+        }
+    } else {
+        switch ($Type) {
+            "group" { Write-Host "##[group]$Message" }
+            "endgroup" { Write-Host "##[endgroup]" }
+            "section" { Write-Host "##[section]$Message" }
+            "error" { Write-Host "##vso[task.logissue type=error]$Message" }
+            "warning" { Write-Host "##vso[task.logissue type=warning]$Message" }
+            default { Write-Host "$Message" }
+        }
+    }
+}
+
 function Test-BcAppXliffTranslations {
     Param(
         [Parameter(Mandatory = $false)]
@@ -46,8 +82,8 @@ function Test-BcAppXliffTranslations {
         [Parameter(Mandatory = $false)]
         [string[]] $restrictErrorsToLanguages = @(),
         [Parameter(Mandatory = $false)]
-        [ValidateSet('no', 'error', 'warning')]
-        [string] $AzureDevOps = 'warning',
+        [ValidateSet('none', 'error', 'warning')]
+        [string] $ErrorSeverity = 'warning',
         [switch] $reportProgress,
         [switch] $printProblems,
         [switch] $printUnitsWithErrors,
@@ -59,6 +95,8 @@ function Test-BcAppXliffTranslations {
         $testAdditionalParameters = @{}
     )
 
+    $hasLoggedErrors = $false
+
     if ((-not $appFolders) -or ($appFolders.Length -eq 0)) {
         $appFolders = (Get-ChildItem $buildProjectFolder -Directory).Name
         Write-Host "-appFolders not explicitly set, using subfolders of $($buildProjectFolder): $appFolders"
@@ -69,7 +107,7 @@ function Test-BcAppXliffTranslations {
     }
 
     $appFolders | ForEach-Object {
-        Write-Host "##[group]Checking translations for `"$_`""
+        Write-CIMessage -Type group -Message "Checking translations for `"$($_)`""
         $appProjectFolder = Join-Path $buildProjectFolder $_
         $appTranslationsFolder = Join-Path $appProjectFolder "Translations"
         Write-Host "Retrieving translation files from $appTranslationsFolder"
@@ -79,20 +117,20 @@ function Test-BcAppXliffTranslations {
         $allUnitsWithIssues = @()
 
         foreach ($targetXliffFile in $targetXliffFiles) {
-            Write-Host "##[section]Processing `"$($targetXliffFile.BaseName)`""
+            Write-CIMessage -Type section -Message "Processing `"$($targetXliffFile.BaseName)`""
             $unitsWithIssues = @()
-            [string]$AzureDevOpsSeverityForFile = $AzureDevOps
-            if (($AzureDevOps -eq 'error') -and ($restrictErrorsToLanguages.Length -gt 0)) {
+            [string]$ErrorSeverityForFile = $ErrorSeverity
+            if (($ErrorSeverity -eq 'error') -and ($restrictErrorsToLanguages.Length -gt 0)) {
                 if ($null -eq ($restrictErrorsToLanguages | Where-Object { $targetXliffFile.Name -match $_ })) {
-                    $AzureDevOpsSeverityForFile = 'warning'
+                    $ErrorSeverityForFile = 'warning'
                 }
-                Write-Host "Translation error severity is '$AzureDevOpsSeverityForFile' for file $($targetXliffFile.FullName)"
+                Write-Host "Translation error severity is '$ErrorSeverityForFile' for file $($targetXliffFile.FullName)"
             }
 
             Write-Host "Syncing to file $($targetXliffFile.FullName)"
-            $unitsWithIssues += Sync-XliffTranslations -sourcePath $baseXliffFile.FullName -targetPath $targetXliffFile.FullName -AzureDevOps $AzureDevOpsSeverityForFile -reportProgress:$reportProgress -printProblems:$printProblems -useSelfClosingTags:$useSelfClosingTags -FormatTranslationUnit $FormatTranslationUnit @syncAdditionalParameters
+            $unitsWithIssues += Sync-XliffTranslations -sourcePath $baseXliffFile.FullName -targetPath $targetXliffFile.FullName -AzureDevOps $ErrorSeverityForFile -reportProgress:$reportProgress -printProblems:$printProblems -useSelfClosingTags:$useSelfClosingTags -FormatTranslationUnit $FormatTranslationUnit @syncAdditionalParameters
             Write-Host "Checking translations in file $($targetXliffFile.FullName)"
-            $unitsWithIssues += Test-XliffTranslations -targetPath $targetXliffFile.FullName -checkForMissing -checkForProblems -translationRules $translationRules -translationRulesEnableAll:$translationRulesEnableAll -AzureDevOps $AzureDevOpsSeverityForFile -reportProgress:$reportProgress -FormatTranslationUnit $FormatTranslationUnit -printProblems:$printProblems @testAdditionalParameters
+            $unitsWithIssues += Test-XliffTranslations -targetPath $targetXliffFile.FullName -checkForMissing -checkForProblems -translationRules $translationRules -translationRulesEnableAll:$translationRulesEnableAll -AzureDevOps $ErrorSeverityForFile -reportProgress:$reportProgress -FormatTranslationUnit $FormatTranslationUnit -printProblems:$printProblems @testAdditionalParameters
 
             $fileIssueCount = $unitsWithIssues.Count
             if ($fileIssueCount -gt 0) {
@@ -102,24 +140,38 @@ function Test-BcAppXliffTranslations {
                     Write-Host $unitsWithIssues
                 }
 
-                if ($AzureDevOpsSeverityForFile -eq 'error') {
+                if ($ErrorSeverityForFile -eq 'error') {
                     $allUnitsWithIssues += $unitsWithIssues
+                    $hasLoggedErrors = $true
                 }
             }
         }
 
-        if (@("error","warning").Contains($AzureDevOps) -and ($targetXliffFiles.Count -eq 0)) {
-            Write-Host "##vso[task.logissue type=$AzureDevOps]There are no target translation files for $($baseXliffFile.Name)"
+        if (@("error", "warning").Contains($ErrorSeverity) -and ($targetXliffFiles.Count -eq 0)) {
+            Write-CIMessage -Type $ErrorSeverity -Message "There are no target translation files for $($baseXliffFile.Name)"
+            if ($ErrorSeverity -eq 'error') {
+                $hasLoggedErrors = $true
+            }
         }
-        Write-Host "##[endgroup]"
+        Write-CIMessage -Type endgroup
 
         $issueCount = $allUnitsWithIssues.Count
-        if (($AzureDevOps -eq 'error') -and ($issueCount -gt 0)) {
-            Write-Host "##vso[task.logissue type=error]$issueCount issues detected in translation files!"
+        if (($ErrorSeverity -eq 'error') -and ($issueCount -gt 0)) {
+            Write-CIMessage -Type error -Message "$issueCount issues detected in translation files!"
+            $hasLoggedErrors = $true
+        }
+    }
+
+    if ($hasLoggedErrors) {
+        Write-CIMessage -Type error -Message "Failing pipeline due to translation issues."
+        if (-not (Is-GitHubActions)) {
             Write-Host "##vso[task.complete result=Failed;]Make step fail"
             exit 0
+        } else {
+            exit 1
         }
     }
 }
+
 Set-Alias -Name Check-BcAppXliffTranslations -Value Test-BcAppXliffTranslations
 Export-ModuleMember -Function Test-BcAppXliffTranslations -Alias Check-BcAppXliffTranslations

--- a/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
+++ b/XliffSync/Public/bc/Test-BcAppXliffTranslations.ps1
@@ -34,41 +34,6 @@
  Specifies additional parameters to pass as arguments to the Test-XliffTranslations function that is invoked by this function.
 #>
 
-function Is-GitHubActions {
-    return [bool]$env:GITHUB_ACTIONS
-}
-
-function Write-CIMessage {
-    param (
-        [Parameter(Mandatory)]
-        [ValidateSet("group", "endgroup", "section", "error", "warning", "info")]
-        [string] $Type,
-
-        [Parameter(Mandatory = $false)]
-        [string] $Message
-    )
-
-    if (Is-GitHubActions) {
-        switch ($Type) {
-            "group" { Write-Host "::group::$Message" }
-            "endgroup" { Write-Host "::endgroup::" }
-            "section" { Write-Host "::group::$Message" }
-            "error" { Write-Host "::error::$Message" }
-            "warning" { Write-Host "::warning::$Message" }
-            default { Write-Host "$Message" }
-        }
-    } else {
-        switch ($Type) {
-            "group" { Write-Host "##[group]$Message" }
-            "endgroup" { Write-Host "##[endgroup]" }
-            "section" { Write-Host "##[section]$Message" }
-            "error" { Write-Host "##vso[task.logissue type=error]$Message" }
-            "warning" { Write-Host "##vso[task.logissue type=warning]$Message" }
-            default { Write-Host "$Message" }
-        }
-    }
-}
-
 function Test-BcAppXliffTranslations {
     Param(
         [Parameter(Mandatory = $false)]
@@ -82,7 +47,7 @@ function Test-BcAppXliffTranslations {
         [Parameter(Mandatory = $false)]
         [string[]] $restrictErrorsToLanguages = @(),
         [Parameter(Mandatory = $false)]
-        [ValidateSet('none', 'error', 'warning')]
+        [ValidateSet('info', 'error', 'warning')]
         [string] $ErrorSeverity = 'warning',
         [switch] $reportProgress,
         [switch] $printProblems,
@@ -128,9 +93,9 @@ function Test-BcAppXliffTranslations {
             }
 
             Write-Host "Syncing to file $($targetXliffFile.FullName)"
-            $unitsWithIssues += Sync-XliffTranslations -sourcePath $baseXliffFile.FullName -targetPath $targetXliffFile.FullName -AzureDevOps $ErrorSeverityForFile -reportProgress:$reportProgress -printProblems:$printProblems -useSelfClosingTags:$useSelfClosingTags -FormatTranslationUnit $FormatTranslationUnit @syncAdditionalParameters
+            $unitsWithIssues += Sync-XliffTranslations -sourcePath $baseXliffFile.FullName -targetPath $targetXliffFile.FullName -ErrorSeverity $ErrorSeverityForFile -reportProgress:$reportProgress -printProblems:$printProblems -useSelfClosingTags:$useSelfClosingTags -FormatTranslationUnit $FormatTranslationUnit @syncAdditionalParameters
             Write-Host "Checking translations in file $($targetXliffFile.FullName)"
-            $unitsWithIssues += Test-XliffTranslations -targetPath $targetXliffFile.FullName -checkForMissing -checkForProblems -translationRules $translationRules -translationRulesEnableAll:$translationRulesEnableAll -AzureDevOps $ErrorSeverityForFile -reportProgress:$reportProgress -FormatTranslationUnit $FormatTranslationUnit -printProblems:$printProblems @testAdditionalParameters
+            $unitsWithIssues += Test-XliffTranslations -targetPath $targetXliffFile.FullName -checkForMissing -checkForProblems -translationRules $translationRules -translationRulesEnableAll:$translationRulesEnableAll -ErrorSeverity $ErrorSeverityForFile -reportProgress:$reportProgress -FormatTranslationUnit $FormatTranslationUnit -printProblems:$printProblems @testAdditionalParameters
 
             $fileIssueCount = $unitsWithIssues.Count
             if ($fileIssueCount -gt 0) {

--- a/XliffSync/Public/tools/ci-logger.ps1
+++ b/XliffSync/Public/tools/ci-logger.ps1
@@ -37,12 +37,12 @@ function Write-CIMessage {
     } else {
         # Fallback für lokale oder nicht unterstützte Umgebungen
         switch ($Type) {
-            "group" { Write-Host "[GROUP] $Message" }
-            "endgroup" { Write-Host "[/GROUP]" }
-            "section" { Write-Host "[SECTION] $Message" }
-            "error" { Write-Host -ForegroundColor Red "[ERROR] $Message" }
-            "warning" { Write-Host -ForegroundColor Yellow "[WARNING] $Message" }
-            default { Write-Host "$Message" }
+            "group"     { Write-Host ""; Write-Host "=== $Message ===" -ForegroundColor Cyan }
+            "endgroup"  { Write-Host "" }
+            "section"   { Write-Host ""; Write-Host "--- $Message ---" -ForegroundColor Cyan }
+            "error"     { Write-Host "[ERROR]   $Message" -ForegroundColor Red }
+            "warning"   { Write-Host "[WARNING] $Message" -ForegroundColor Yellow }
+            default     { Write-Host "[INFO]    $Message" }
         }
     }
 }

--- a/XliffSync/Public/tools/ci-logger.ps1
+++ b/XliffSync/Public/tools/ci-logger.ps1
@@ -1,0 +1,69 @@
+function Is-GitHubActions {
+    return $env:GITHUB_ACTIONS -eq "true"
+}
+
+function Is-AzureDevOps {
+    return [bool]$env:AGENT_NAME
+}
+
+function Write-CIMessage {
+    param (
+        [Parameter(Mandatory)]
+        [ValidateSet("group", "endgroup", "section", "error", "warning", "info")]
+        [string] $Type,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Message
+    )
+
+    if (Is-GitHubActions) {
+        switch ($Type) {
+            "group" { Write-Host "::group::$Message" }
+            "endgroup" { Write-Host "::endgroup::" }
+            "section" { Write-Host "::group::$Message" }  # GitHub kennt keinen "section", also wie group
+            "error" { Write-Host "::error::$Message" }
+            "warning" { Write-Host "::warning::$Message" }
+            default { Write-Host "$Message" }
+        }
+    } elseif (Is-AzureDevOps) {
+        switch ($Type) {
+            "group" { Write-Host "##[group]$Message" }
+            "endgroup" { Write-Host "##[endgroup]" }
+            "section" { Write-Host "##[section]$Message" }
+            "error" { Write-Host "##vso[task.logissue type=error]$Message" }
+            "warning" { Write-Host "##vso[task.logissue type=warning]$Message" }
+            default { Write-Host "$Message" }
+        }
+    } else {
+        # Fallback für lokale oder nicht unterstützte Umgebungen
+        switch ($Type) {
+            "group" { Write-Host "[GROUP] $Message" }
+            "endgroup" { Write-Host "[/GROUP]" }
+            "section" { Write-Host "[SECTION] $Message" }
+            "error" { Write-Host -ForegroundColor Red "[ERROR] $Message" }
+            "warning" { Write-Host -ForegroundColor Yellow "[WARNING] $Message" }
+            default { Write-Host "$Message" }
+        }
+    }
+}
+
+function Write-CIProgress {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Message,
+
+        [int] $PercentComplete = 0,
+
+        [ValidateSet("info", "warning", "error")]
+        [string] $ErrorSeverity
+    )
+
+    if (Is-GitHubActions) {
+        Write-CIMessage -Type info -Message "[Progress $PercentComplete%] $Message"
+    } elseif ($ErrorSeverity -ne 'info') {
+        Write-Host "##vso[task.setprogress value=$PercentComplete;]$Message"
+    } else {
+        Write-Progress -Activity $Message -PercentComplete $PercentComplete
+    }
+}
+

--- a/XliffSync/Public/tools/ci-logger.ps1
+++ b/XliffSync/Public/tools/ci-logger.ps1
@@ -20,7 +20,7 @@ function Write-CIMessage {
         switch ($Type) {
             "group" { Write-Host "::group::$Message" }
             "endgroup" { Write-Host "::endgroup::" }
-            "section" { Write-Host "::group::$Message" }  # GitHub kennt keinen "section", also wie group
+            "section" { Write-Host "::group::$Message" }  # GitHub does not support "section", treat as "group"
             "error" { Write-Host "::error::$Message" }
             "warning" { Write-Host "::warning::$Message" }
             default { Write-Host "$Message" }
@@ -35,7 +35,7 @@ function Write-CIMessage {
             default { Write-Host "$Message" }
         }
     } else {
-        # Fallback für lokale oder nicht unterstützte Umgebungen
+        # Fallback for local or unsupported environments
         switch ($Type) {
             "group"     { Write-Host ""; Write-Host "=== $Message ===" -ForegroundColor Cyan }
             "endgroup"  { Write-Host "" }

--- a/XliffSync/XliffSync.psm1
+++ b/XliffSync/XliffSync.psm1
@@ -1,6 +1,9 @@
 [cmdletbinding()]
 param()
 
+# Load shared tools (e.g. logger)
+. "$PSScriptRoot\Public\tools\ci-logger.ps1"
+
 # Load Model (e.g., classes)
 $modelList = @(
     'XlfDocument'


### PR DESCRIPTION
Added Write-CIMessage utility in tools/ci-logger.ps1:

Handles CI platform-aware logging based on keywords/types (info, warning, error, section, group).
Supports GitHub Actions, Azure DevOps.
Adds color to local terminal or unsupported platforms to improve readability.
Replaced Write-Host calls that have DevOps-specific syntax (##vso[...]) with Write-CIMessage.
Replaced $AzureDevOps parameter in all relevant scripts with $ErrorSeverity parameter (info, warning, error)
![image](https://github.com/user-attachments/assets/3597f733-95a6-4d40-a356-3d37f6e23267)
![image](https://github.com/user-attachments/assets/938a426d-24aa-44f3-afb5-040a2d96fcb0)

